### PR TITLE
[FEAT] 배송등록 추가와 추가구독 api 연동

### DIFF
--- a/app/src/main/java/com/please/data/api/SellerProfileApi.kt
+++ b/app/src/main/java/com/please/data/api/SellerProfileApi.kt
@@ -5,11 +5,16 @@ import com.please.data.models.ApiResponse
 import com.please.data.models.PasswordUpdateRequest
 import com.please.data.models.SellerProfile
 import com.please.data.models.seller.DeliveryBaseResponse
+import com.please.data.models.seller.PlanId
+import com.please.data.models.seller.RegisterDelivery
+import com.please.data.models.seller.RegisterDeliveryResponse
 import com.please.data.models.seller.SellerHomeInfo
+import com.please.data.models.seller.SubscriptionResponse
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.QueryMap
 
@@ -19,36 +24,26 @@ interface SellerProfileApi {
     @GET("owner/home")
     suspend fun ownerHome(@Header("authorization") authorization: String): Response<SellerHomeInfo> //Response<ApiResponse<SellerHomeInfo>>
 
+
     //shipment
     @GET("owner/shipment-history/completed") //월간 내역에 대한 조회 기능. - 아래 리스트랑은 월간조회이냐 일간조회이냐 차이뿐임.
     suspend fun shipmentCompleted(@Header("authorization") authorization: String, @QueryMap params: Map<String, String>): Response<DeliveryBaseResponse>
 
     @GET("owner/shipment/list")
     suspend fun shipmentList(@Header("authorization") authorization: String, @QueryMap params: Map<String, String>): Response<DeliveryBaseResponse>
-/*
-    @GET("owner/shipment/trackingNumber")
-    suspend fun shipmentTrack(@Header("authorization") authorization: String): Response<SellerHomeInfo> //Response<ApiResponse<SellerHomeInfo>>
+
+    // 밀림.
+    //@GET("owner/shipment/trackingNumber") // TODO 반환값 변경.
+    //suspend fun shipmentTrack(@Header("authorization") authorization: String): Response<SellerHomeInfo> //Response<ApiResponse<SellerHomeInfo>>
 
     @POST("owner/shipment/register")
-    suspend fun shipmentRegister(@Header("authorization") authorization: String): Response<SellerHomeInfo> //Response<ApiResponse<SellerHomeInfo>>
-
-    //points
-    @POST("owner/points/subscribe")
-    suspend fun subscribe(@Header("authorization") authorization: String): Response<SellerHomeInfo> //Response<ApiResponse<SellerHomeInfo>>
-
-    @POST("owner/points/charge")
-    suspend fun charge(@Header("authorization") authorization: String): Response<SellerHomeInfo> //Response<ApiResponse<SellerHomeInfo>>
-
-    @GET("owner/points/history")
-    suspend fun history(@Header("authorization") authorization: String): Response<SellerHomeInfo> //Response<ApiResponse<SellerHomeInfo>>
+    suspend fun shipmentRegister(@Header("authorization") authorization: String, @Body delivery: RegisterDelivery): Response<RegisterDeliveryResponse> //Response<ApiResponse<SellerHomeInfo>>
 
 
-     */
-
-    // 마이페이지
+    // TODO 이후 아래는 모두 미사용 상태
+    // 마이페이지 - 현재 없음.
     //router.post('/my-page', updateStoreInfo); // 가게 정보 수정하기
     //router.post('/my-page/change-password', changePassword); // 비밀번호 수정하기
-
 
     //none
     @GET("owner/profile")

--- a/app/src/main/java/com/please/data/api/SubscriptionApi.kt
+++ b/app/src/main/java/com/please/data/api/SubscriptionApi.kt
@@ -1,14 +1,25 @@
 package com.please.data.api
 
-import com.please.data.models.SubscriptionResponse
+import com.please.data.models.seller.PlanId
+import com.please.data.models.seller.SubscriptionResponse
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface SubscriptionApi {
-    @POST("subscription/subscribe")
-    suspend fun subscribeToPlan(@Body request: Map<String, Int>): Response<SubscriptionResponse>
+
+    //points
+    @POST("owner/points/subscribe")
+    suspend fun subscribe(@Header("authorization") authorization: String, @Body id: PlanId): Response<SubscriptionResponse> //Response<ApiResponse<SellerHomeInfo>>
 
     @POST("subscription/purchase-points")
     suspend fun purchasePoints(): Response<SubscriptionResponse>
+
+    /* - 프론트 UI 미존재. 따라서 미구현.
+    @POST("owner/points/charge")
+    suspend fun charge(@Header("authorization") authorization: String): Response<SellerHomeInfo> //Response<ApiResponse<SellerHomeInfo>>
+    @GET("owner/points/history")
+    suspend fun history(@Header("authorization") authorization: String): Response<SellerHomeInfo> //Response<ApiResponse<SellerHomeInfo>>
+     */
 }

--- a/app/src/main/java/com/please/data/models/SubscriptionPlan.kt
+++ b/app/src/main/java/com/please/data/models/SubscriptionPlan.kt
@@ -1,9 +1,0 @@
-package com.please.data.models
-
-data class SubscriptionPlan(
-    val id: Int,
-    val name: String,
-    val price: Int,
-    val points: Int,
-    var isSelected: Boolean = false
-)

--- a/app/src/main/java/com/please/data/models/SubscriptionResponse.kt
+++ b/app/src/main/java/com/please/data/models/SubscriptionResponse.kt
@@ -1,6 +1,0 @@
-package com.please.data.models
-
-data class SubscriptionResponse(
-    val success: Boolean,
-    val message: String
-)

--- a/app/src/main/java/com/please/data/models/seller/DeliveryInfo.kt
+++ b/app/src/main/java/com/please/data/models/seller/DeliveryInfo.kt
@@ -28,6 +28,25 @@ data class DeliveryInfo(
     val isCautionRequired: Boolean = false, // 취급주의 여부
     val trackingNumber: String? = null // 운송장 번호 (시스템에서 자동 생성될 수 있음)
 )
+data class RegisterDelivery(
+    val productName: String,
+    val recipientName: String,
+    val recipientPhone: String,
+    val recipientAddr: String, // 배송 주소
+    val detailAddress: String? = null, // 상세 주소
+    val size: PackageSize,
+    val caution: Boolean,
+    val pickupScheduledDate: String, // 수거 날짜
+    //val isCautionRequired: Boolean = false, // 취급주의 여부
+    //val trackingNumber: String? = null
+)
+
+data class RegisterDeliveryResponse(
+    val status: Boolean,
+    val message: String,
+    val parcelId: Int, // 기입된 고유 번호. 쓸일이 있을진 모르겠네.
+    val usedPoints: Int
+)
 
 data class ComTrackPack(
     val trackingCode: String,
@@ -36,8 +55,8 @@ data class ComTrackPack(
     val detailAddress: String,
     val productName: String,
     val status: String, //enum 이면 좋은데... 스키마 양식이 바뀜
-    val deliveryCompletedAt: String,
-    val pickupScheduledDate: String,
+    val deliveryCompletedAt: Date, //반환 문제가 있다면, String으로 바꾸고, viewmodel에서 formatDate 함수로 변경반환
+    val pickupScheduledDate: Date,
     val size: PackageSize
 )
 

--- a/app/src/main/java/com/please/data/models/seller/SubscriptionPlan.kt
+++ b/app/src/main/java/com/please/data/models/seller/SubscriptionPlan.kt
@@ -1,9 +1,27 @@
 package com.please.data.models.seller
 
+import java.util.Date
+
+//미사용
 data class SubscriptionPlan(
     val id: Int,
     val name: String,
     val price: Int,
     val points: Int,
     val isSelected: Boolean = false
+)
+
+//일단 양식 맞추기 위한 클래스 생성
+data class PlanId(
+    val planId: Int
+)
+
+//반환값이 있긴한데, 프론트에서 쓰이는지 모르겠음.
+data class SubscriptionResponse(
+    val status: Boolean,
+    val message: String,
+    val planName: String,
+    val grantedPoints: Int,
+    val currentPoints: Int,
+    val subscriptionStartDate: Date
 )

--- a/app/src/main/java/com/please/data/repositories/DeliveryRepository.kt
+++ b/app/src/main/java/com/please/data/repositories/DeliveryRepository.kt
@@ -117,7 +117,7 @@ class DeliveryRepository @Inject constructor() {
                 recipientPhone = "010-1234-5678", // TODO 미사용 - json 양식에 미기입 상태. 필요시 백엔드 수정
                 address = pack.recipientAddr,
                 detailAddress = pack.detailAddress,
-                pickupDate = dateFromStringFormat(pack.pickupScheduledDate),
+                pickupDate = pack.pickupScheduledDate,
                 packageSize = pack.size,
                 status = convertStatus(pack.status),
                 trackingNumber = pack.trackingCode
@@ -129,6 +129,7 @@ class DeliveryRepository @Inject constructor() {
         return deliveryList
     }
 
+    /*
     fun dateFromStringFormat(pack: String): Date{
         val dateString = pack // "2025-05-25T04:36:32.968Z"
         val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
@@ -140,6 +141,7 @@ class DeliveryRepository @Inject constructor() {
         //val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.getDefault())
         return date
     }
+     */
 
     // 현재 데이터 상 분류가 총 6개로 나뉨...
     // 해당 분류를 프론트 기존 형식으로 임의 분류

--- a/app/src/main/java/com/please/data/repositories/SellerRepository.kt
+++ b/app/src/main/java/com/please/data/repositories/SellerRepository.kt
@@ -2,6 +2,8 @@ package com.please.data.repositories
 
 import com.please.data.api.SellerProfileApi
 import com.please.data.models.seller.DeliveryBaseResponse
+import com.please.data.models.seller.RegisterDelivery
+import com.please.data.models.seller.RegisterDeliveryResponse
 import com.please.data.models.seller.SellerHomeInfo
 import javax.inject.Inject
 import retrofit2.Response
@@ -41,6 +43,14 @@ class SellerRepository @Inject constructor(
 
         return ownerService.shipmentList("Bearer $token", params)
     }
+
+    suspend fun registerShipment(token: String, delivery: RegisterDelivery): Response<RegisterDeliveryResponse>{
+        return ownerService.shipmentRegister("Bearer $token", delivery)
+    }
+
+
+
+
 
     /*
     suspend fun login(id: String, password: String, userType: UserType): Response<LoginResponse> {

--- a/app/src/main/java/com/please/data/repositories/SubscriptionRepository.kt
+++ b/app/src/main/java/com/please/data/repositories/SubscriptionRepository.kt
@@ -1,13 +1,23 @@
 package com.please.data.repositories
 
 import com.please.data.api.SubscriptionApi
-import com.please.data.models.SubscriptionResponse
+import com.please.data.models.seller.PlanId
+import com.please.data.models.seller.RegisterDelivery
+import com.please.data.models.seller.RegisterDeliveryResponse
+import com.please.data.models.seller.SubscriptionResponse
+import retrofit2.Response
 import javax.inject.Inject
 
 class SubscriptionRepository @Inject constructor(
     private val subscriptionApi: SubscriptionApi
 ) {
     // 구독 신청
+    suspend fun registerShipment(token: String, id: PlanId): Response<SubscriptionResponse>{
+        return subscriptionApi.subscribe("Bearer $token", id)
+    }
+
+    /*
+    //구독 (구)
     suspend fun subscribeToPlan(planId: Int): Result<SubscriptionResponse> {
         return try {
             val response = subscriptionApi.subscribeToPlan(mapOf("planId" to planId))
@@ -20,4 +30,5 @@ class SubscriptionRepository @Inject constructor(
             Result.failure(e)
         }
     }
+     */
 }

--- a/app/src/main/java/com/please/ui/seller/delivery/DeliveryInputViewModel.kt
+++ b/app/src/main/java/com/please/ui/seller/delivery/DeliveryInputViewModel.kt
@@ -1,19 +1,30 @@
 package com.please.ui.seller.delivery
 
+import android.util.Log
+import android.widget.Toast
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.please.data.models.seller.DeliveryInfo
 import com.please.data.models.seller.PackageSize
+import com.please.data.models.seller.RegisterDelivery
+import com.please.data.models.seller.RegisterDeliveryResponse
+import com.please.data.repositories.AuthRepository
 import com.please.data.repositories.DeliveryRepository
+import com.please.data.repositories.SellerRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
+import java.util.*
 
 @HiltViewModel
 class DeliveryInputViewModel @Inject constructor(
-    private val repository: DeliveryRepository
+    private val repository: DeliveryRepository,
+    private val repository_sell: SellerRepository
 ) : ViewModel() {
 
     // 입력 필드 상태
@@ -40,6 +51,9 @@ class DeliveryInputViewModel @Inject constructor(
 
     private val _pickupDate = MutableLiveData<Date>()
     val pickupDate: LiveData<Date> = _pickupDate
+
+    private val _registerResult = MutableLiveData<RegisterDeliveryResponse>()
+    val registerResult: LiveData<RegisterDeliveryResponse> = _registerResult
 
     // 저장 성공 여부
     private val _saveResult = MutableLiveData<SaveResult>()
@@ -89,6 +103,8 @@ class DeliveryInputViewModel @Inject constructor(
 
     // 배송 정보 저장
     fun saveDeliveryInfo() {
+        val token = AuthRepository.AppState.userToken ?: "none"
+
         // 필수 입력값 확인
         val productName = _productName.value
         val recipientName = _recipientName.value
@@ -109,24 +125,40 @@ class DeliveryInputViewModel @Inject constructor(
         }
 
         // 배송 정보 생성
-        val deliveryInfo = DeliveryInfo(
-            id = UUID.randomUUID().toString(),
+        val deliveryInfo = RegisterDelivery(
             productName = productName,
             recipientName = recipientName,
             recipientPhone = recipientPhone,
-            address = address,
+            recipientAddr = address,
             detailAddress = _detailAddress.value,
-            pickupDate = pickupDate,
-            packageSize = packageSize,
-            isCautionRequired = _isCautionRequired.value ?: false
+            size = packageSize,
+            caution = isCautionRequired.value ?: false,
+            pickupScheduledDate = formatDateForMySQL(pickupDate)
+        //isCautionRequired = _isCautionRequired.value ?: false
         )
 
-        // 저장
-        try {
-            repository.addDelivery(deliveryInfo)
-            _saveResult.value = SaveResult.Success
-        } catch (e: Exception) {
-            _saveResult.value = SaveResult.Error("배송 정보 저장에 실패했습니다: ${e.message}")
+        //저장한 방식으로 백엔드 서버에 갱신.
+        viewModelScope.launch {
+            try {
+                val response = repository_sell.registerShipment(token, deliveryInfo)
+                Log.d("Delivery/Register", deliveryInfo.toString())
+                Log.d("Delivery/Register", response.body().toString())
+
+                //성공시 리스트 생성 양식 기입
+                if (response.isSuccessful && response.body() != null && response.body()?.status == true) {
+                    //여기서 response 반환. 어디다가 쓰느냐라... 현재 지정 없음.
+                    Log.d("Delivery/Regiter", "배송 등록이 완료되었습니다.")
+                    _registerResult.value = response.body()!!
+                    _saveResult.value = SaveResult.Success
+                    // 로컬 저장 - 임의 제거
+                    //repository.addDelivery(deliveryInfo)
+                } else {
+                    Log.d("Delivery/Register" , "배송 내역이 없습니다.")
+                }
+            } catch (e: Exception) {
+                _saveResult.value = SaveResult.Error("배송 정보 저장에 실패했습니다: ${e.message}")
+                Log.d("Delivery/Register" , e.message.toString())
+            }
         }
     }
 
@@ -135,4 +167,11 @@ class DeliveryInputViewModel @Inject constructor(
         object Success : SaveResult()
         data class Error(val message: String) : SaveResult()
     }
+
+    fun formatDateForMySQL(date: Date): String {
+        val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+        formatter.timeZone = TimeZone.getTimeZone("UTC") // 필요 시 'Asia/Seoul' 등으로 변경
+        return formatter.format(date)
+    }
+
 }

--- a/app/src/main/java/com/please/ui/seller/subscription/SellerSubscriptionFragment.kt
+++ b/app/src/main/java/com/please/ui/seller/subscription/SellerSubscriptionFragment.kt
@@ -10,7 +10,6 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.please.data.models.SubscriptionPlan
 import com.please.databinding.FragmentSellerSubscriptionBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch


### PR DESCRIPTION
## 🔥 무엇을 구현했나요?

- 소상공인 api 기능 연동

## 🛠 변경사항 요약

- 배송등록 추가
- 추가 구독 기능 연결

## 📸 스크린샷 (선택)

-

## 📌 참고사항

- 쓰레기통 버튼을 통한 등록취소 미구현
- 해당 기능을 위한 api 배포 필요(클라우드)

## ✅ 체크리스트

- [ ] 코드에 불필요한 부분이 없는가?
- [ ] 테스트는 충분한가?
- [ ] 문서화는 되었는가?
