### PR TITLE
[feat] 배송기사 홈화면 api 연결 #32

### DIFF
--- a/app/src/main/java/com/please/data/api/DriverApiService.kt
+++ b/app/src/main/java/com/please/data/api/DriverApiService.kt
@@ -1,0 +1,18 @@
+package com.please.data.api
+
+import com.please.data.models.driver.DriverHomeResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Header
+
+interface DriverApiService {
+    
+    /**
+     * 배송기사 홈 화면 정보를 가져오는 API
+     * 
+     * @param authorization Bearer 토큰
+     * @return 배송기사 홈 화면에 필요한 정보 (담당 위치, 수행 건수, 포인트 등)
+     */
+    @GET("driver/home")
+    suspend fun getDriverHome(@Header("Authorization") authorization: String): Response<DriverHomeResponse>
+}

--- a/app/src/main/java/com/please/data/models/driver/DriverHomeResponse.kt
+++ b/app/src/main/java/com/please/data/models/driver/DriverHomeResponse.kt
@@ -2,7 +2,7 @@ package com.please.data.models.driver
 
 import com.google.gson.annotations.SerializedName
 
-// API 응답을 위한 데이터 클래스 (추후 API 연동 시 사용)
+// API 응답을 위한 데이터 클래스
 data class DriverHomeResponse(
     @SerializedName("status")
     val status: Boolean,
@@ -12,27 +12,44 @@ data class DriverHomeResponse(
 
 data class DriverHomeData(
     @SerializedName("region")
-    val region: String,
+    val region: String = "",
     @SerializedName("monthlyCount")
     val monthlyCount: MonthlyCount,
     @SerializedName("todayCount")
     val todayCount: TodayCount,
     @SerializedName("points")
-    val points: Int
+    val points: Int = 0
 )
 
 data class MonthlyCount(
     @SerializedName("pickup")
-    val pickup: Int,
+    val pickup: Int = 0,
     @SerializedName("delivery")
-    val delivery: Int,
+    val delivery: Int = 0,
     @SerializedName("total")
-    val total: Int
+    val total: Int = 0
 )
 
+// API 응답에서 문자열로 올 수 있는 필드들을 위한 조정
 data class TodayCount(
     @SerializedName("pickup")
-    val pickup: Int,
+    private val _pickup: Any = 0,
     @SerializedName("delivery")
+    private val _delivery: Any = 0
+) {
+    // pickup 값을 안전하게 Int로 변환
+    val pickup: Int
+        get() = when (_pickup) {
+            is Int -> _pickup
+            is String -> _pickup.toIntOrNull() ?: 0
+            else -> 0
+        }
+    
+    // delivery 값을 안전하게 Int로 변환
     val delivery: Int
-)
+        get() = when (_delivery) {
+            is Int -> _delivery
+            is String -> _delivery.toIntOrNull() ?: 0
+            else -> 0
+        }
+}

--- a/app/src/main/java/com/please/data/repositories/DriverRepository.kt
+++ b/app/src/main/java/com/please/data/repositories/DriverRepository.kt
@@ -1,0 +1,23 @@
+package com.please.data.repositories
+
+import com.please.data.api.DriverApiService
+import com.please.data.models.driver.DriverHomeResponse
+import retrofit2.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DriverRepository @Inject constructor(
+    private val driverApiService: DriverApiService
+) {
+    
+    /**
+     * 배송기사 홈 화면 정보를 가져오는 함수
+     * 
+     * @param token 인증 토큰
+     * @return 배송기사 홈 화면 데이터
+     */
+    suspend fun getDriverHome(token: String): Response<DriverHomeResponse> {
+        return driverApiService.getDriverHome("Bearer $token")
+    }
+}

--- a/app/src/main/java/com/please/di/NetworkModule.kt
+++ b/app/src/main/java/com/please/di/NetworkModule.kt
@@ -1,12 +1,16 @@
 package com.please.di
 
+import android.util.Log
 import com.please.data.api.AuthApiService
+import com.please.data.api.DriverApiService
 import com.please.data.api.SellerProfileApi
 import com.please.data.api.SubscriptionApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Singleton
@@ -23,9 +27,23 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideRetrofit(): Retrofit {
+    fun provideOkHttpClient(): OkHttpClient {
+        val loggingInterceptor = HttpLoggingInterceptor { message ->
+            Log.d("API_CALL", message)
+        }
+        loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
+
+        return OkHttpClient.Builder()
+            .addInterceptor(loggingInterceptor)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
-            .baseUrl(BASE_URL) // 임시 URL
+            .baseUrl(BASE_URL)
+            .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }
@@ -46,5 +64,11 @@ object NetworkModule {
     @Singleton
     fun provideSellerProfileApi(retrofit: Retrofit): SellerProfileApi {
         return retrofit.create(SellerProfileApi::class.java)
+    }
+    
+    @Provides
+    @Singleton
+    fun provideDriverApiService(retrofit: Retrofit): DriverApiService {
+        return retrofit.create(DriverApiService::class.java)
     }
 }

--- a/app/src/main/java/com/please/ui/driver/home/DriverHomeFragment.kt
+++ b/app/src/main/java/com/please/ui/driver/home/DriverHomeFragment.kt
@@ -33,14 +33,24 @@ class DriverHomeFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         
         setupObservers()
+        setupListeners()
+    }
+
+    private fun setupListeners() {
+        // 포인트 카드 클릭 시 데이터 새로고침
+        binding.pointsCard.setOnClickListener {
+            Toast.makeText(requireContext(), "데이터를 새로고침 중...", Toast.LENGTH_SHORT).show()
+            viewModel.refreshData()
+        }
     }
 
     private fun setupObservers() {
         viewModel.homeInfoState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is HomeInfoState.Loading -> {
-                    // 로딩 상태 처리 (필요하다면 ProgressBar 표시)
+                    // 로딩 상태 처리
                     Log.d("DRIVER_HOME/UI", "Loading...")
+                    Toast.makeText(requireContext(), "데이터 로딩 중...", Toast.LENGTH_SHORT).show()
                 }
                 is HomeInfoState.Success -> {
                     // 성공 시 UI 업데이트
@@ -50,7 +60,7 @@ class DriverHomeFragment : Fragment() {
                 is HomeInfoState.Error -> {
                     // 에러 처리
                     Log.d("DRIVER_HOME/UI", "Error: ${state.message}")
-                    Toast.makeText(requireContext(), state.message, Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(), "오류: ${state.message}", Toast.LENGTH_LONG).show()
                 }
             }
         }
@@ -59,20 +69,37 @@ class DriverHomeFragment : Fragment() {
     private fun updateUI(response: com.please.data.models.driver.DriverHomeResponse) {
         val data = response.data
         binding.apply {
-            // 담당 위치 업데이트
-            tvLocation.text = data.region
+            // 담당 위치 업데이트 - 빈 값 처리
+            tvLocation.text = if (data.region.isNullOrBlank()) {
+                "지역 정보 없음"
+            } else {
+                data.region
+            }
 
             // 이번 달 수행 건수 업데이트
             tvMonthlyPickup.text = data.monthlyCount.pickup.toString()
             tvMonthlyDelivery.text = data.monthlyCount.delivery.toString()
             tvMonthlyTotal.text = data.monthlyCount.total.toString()
 
-            // 오늘 업무 업데이트
-            tvTodayPickup.text = data.todayCount.pickup.toString()
-            tvTodayDelivery.text = data.todayCount.delivery.toString()
+            // 오늘 업무 업데이트 - 0값 처리 (필요시 "업무 없음" 등의 메시지 표시 가능)
+            tvTodayPickup.text = if (data.todayCount.pickup == 0) {
+                "0"
+            } else {
+                data.todayCount.pickup.toString()
+            }
+            
+            tvTodayDelivery.text = if (data.todayCount.delivery == 0) {
+                "0"
+            } else {
+                data.todayCount.delivery.toString()
+            }
 
-            // 적립 포인트 업데이트
-            tvPoints.text = data.points.toString()
+            // 적립 포인트 업데이트 - 0값 처리
+            tvPoints.text = if (data.points == 0) {
+                "0"
+            } else {
+                data.points.toString()
+            }
         }
     }
 

--- a/app/src/main/java/com/please/ui/driver/home/DriverHomeViewModel.kt
+++ b/app/src/main/java/com/please/ui/driver/home/DriverHomeViewModel.kt
@@ -8,8 +8,10 @@ import androidx.lifecycle.viewModelScope
 import com.please.data.models.driver.DriverHomeResponse
 import com.please.data.repositories.AuthRepository
 import com.please.data.repositories.DriverRepository
+import com.please.di.BASE_URL
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -26,22 +28,35 @@ class DriverHomeViewModel @Inject constructor(
     }
 
     private fun loadHomeInfo(token: String) {
-        if(token == "none") Log.d("DRIVER_HOME/CALL/ERROR", "none")
+        if(token == "none") {
+            Log.e("DRIVER_HOME/CALL/ERROR", "토큰이 없습니다. 로그인 필요.")
+            _homeInfoState.value = HomeInfoState.Error("인증 토큰이 없습니다. 다시 로그인해주세요.")
+            return
+        }
 
+        Log.d("DRIVER_HOME/TOKEN", "사용 토큰: $token")
         _homeInfoState.value = HomeInfoState.Loading
 
         viewModelScope.launch {
-            Log.d("DRIVER_HOME/CALL", token)
+            Log.d("DRIVER_HOME/CALL", "API 호출 시작: ${BASE_URL}driver/home")
             try {
                 // API 호출
                 val response = repository.getDriverHome(token)
-                Log.d("DRIVER_HOME/CALL", token)
-                Log.d("DRIVER_HOME/CALL", response.body().toString())
-
-                // 성공 시, res body 반환
-                if (response.isSuccessful && response.body() != null) {
-                    _homeInfoState.value = HomeInfoState.Success(response.body()!!)
+                
+                if (response.isSuccessful) {
+                    val responseBody = response.body()
+                    Log.d("DRIVER_HOME/RESPONSE", "응답 성공: $responseBody")
+                    
+                    if (responseBody != null) {
+                        _homeInfoState.value = HomeInfoState.Success(responseBody)
+                    } else {
+                        Log.e("DRIVER_HOME/RESPONSE", "응답 본문이 null입니다.")
+                        _homeInfoState.value = HomeInfoState.Error("서버에서 빈 응답이 반환되었습니다.")
+                    }
                 } else {
+                    val errorBody = response.errorBody()?.string()
+                    Log.e("DRIVER_HOME/ERROR", "HTTP 오류: ${response.code()}, 메시지: ${response.message()}, 본문: $errorBody")
+                    
                     val errorMessage = when (response.code()) {
                         401 -> "인증에 실패했습니다. 다시 로그인해주세요."
                         404 -> "등록된 기사 정보가 없습니다."
@@ -49,9 +64,12 @@ class DriverHomeViewModel @Inject constructor(
                     }
                     _homeInfoState.value = HomeInfoState.Error(errorMessage)
                 }
+            } catch (e: HttpException) {
+                Log.e("DRIVER_HOME/HTTP_EXCEPTION", "HTTP 예외: ${e.code()}, 메시지: ${e.message()}", e)
+                _homeInfoState.value = HomeInfoState.Error("네트워크 오류: ${e.message()}")
             } catch (e: Exception) {
-                Log.d("DRIVER_HOME/CALL", e.message.toString())
-                _homeInfoState.value = HomeInfoState.Error("홈화면 조회에 실패했습니다: ${e.message}")
+                Log.e("DRIVER_HOME/EXCEPTION", "예외 발생: ${e.javaClass.simpleName}, 메시지: ${e.message}", e)
+                _homeInfoState.value = HomeInfoState.Error("오류가 발생했습니다: ${e.message}")
             }
         }
     }


### PR DESCRIPTION
## 🔥 무엇을 구현했나요?

- 배송기사 홈화면 api 연결

## 🛠 변경사항 요약

- 배송기사 홈 화면에 백엔드 API를 연동하여 실시간 정보 표시
- 택배기사의 일별 배송 건수 및 포인트 데이터를 서버에서 받아와 화면에 출력
- ViewModel을 통해 API 요청 처리 및 UI에 바인딩

## 📸 스크린샷 (선택)

- 
<img width="317" alt="image" src="https://github.com/user-attachments/assets/c3a0caae-b8e4-4227-810d-2a929cb2f510" />


## 📌 참고사항

-

## ✅ 체크리스트

- [ ] 코드에 불필요한 부분이 없는가?
- [ ] 테스트는 충분한가?
- [ ] 문서화는 되었는가?
